### PR TITLE
Remove spurious printing to stderr in rs6000 backend

### DIFF
--- a/gcc/config/rs6000/rs6000.c
+++ b/gcc/config/rs6000/rs6000.c
@@ -18,6 +18,7 @@
    along with GCC; see the file COPYING3.  If not see
    <http://www.gnu.org/licenses/>.  */
 
+
 #include "config.h"
 #include "system.h"
 #include "coretypes.h"
@@ -24502,7 +24503,7 @@ rs6000_emit_prologue (void)
 #define NOT_INUSE(R) do {} while (0)
 #endif
 
-  fprintf (stderr, "prologue begins\n");
+
 
   if (DEFAULT_ABI == ABI_ELFv2)
     {
@@ -24767,8 +24768,7 @@ rs6000_emit_prologue (void)
   /* Do any required saving of fpr's.  If only one or two to save, do
      it ourselves.  Otherwise, call function.  */
   if (!WORLD_SAVE_P (info) && (strategy & SAVE_INLINE_FPRS))
-    {
-      fprintf (stderr, "save fprs with emit frame save\n");
+	{
       int i;
       if (!TARGET_S2PP){
         for (i = 0; i < 64 - info->first_fp_reg_save; i++)


### PR DESCRIPTION
There are some leftover debug fprintf in the rs6000 backend, they should either be guarded by a debug flag or removed completely. I've opted for the latter because they do not really print out useful information and can easily be readded later.